### PR TITLE
 Py-3.7-win7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ COPY mkuserwineprefix /opt/
 RUN xvfb-run sh /tmp/helper/wine-init.sh
 
 # renovate: datasource=github-tags depName=python/cpython versioning=pep440
-ARG PYTHON_VERSION=3.11.2
+ARG PYTHON_VERSION=3.7.9
+ARG PYINSTALLER_VERSION=5.8.0
+ARG UCRT_VERSION=10.0.22621.1
 # renovate: datasource=github-releases depName=upx/upx versioning=loose
 ARG UPX_VERSION=3.96
 
@@ -19,19 +21,22 @@ RUN umask 0 && cd /tmp/helper && \
   curl -LOOO \
     https://www.python.org/ftp/python/${PYTHON_VERSION}/python-${PYTHON_VERSION}-amd64.exe{,.asc} \
     https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-win64.zip \
+    https://github.com/huangqinjin/ucrt/releases/download/10.0.22621.0/ucrt-x64-${UCRT_VERSION}.zip \ 
   && \
   gpgv --keyring ./keys.gpg python-${PYTHON_VERSION}-amd64.exe.asc python-${PYTHON_VERSION}-amd64.exe && \
   sha256sum -c SHA256SUMS.txt && \
   xvfb-run sh -c "\
-    wine python-${PYTHON_VERSION}-amd64.exe /quiet TargetDir=C:\\Python310 \
+    wine python-${PYTHON_VERSION}-amd64.exe /quiet TargetDir=C:\\Python \
       Include_doc=0 InstallAllUsers=1 PrependPath=1; \
     wineserver -w" && \
   unzip upx*.zip && \
   mv -v upx*/upx.exe ${WINEPREFIX}/drive_c/windows/ && \
+  unzip ucrt*.zip && \
+  mv ucrt*/* ${WINEPREFIX}/drive_c/Python &&\
   cd .. && rm -Rf helper
 
 # Install some python software
 RUN umask 0 && xvfb-run sh -c "\
-  wine pip install --no-warn-script-location pyinstaller; \
+  wine pip install --no-warn-script-location "pyinstaller==${PYINSTALLER_VERSION}"; \
   wineserver -w"
 


### PR DESCRIPTION
I suggest adding a branch ` Py-3.7-win7` and docker tag `tobix/pywine:3.7-win7` with python 3.7 and ucrt lib to support windows 7. 
I add windows ucrt lib from [huangqinjin/ucrt](https://github.com/huangqinjin/ucrt) and update pyinstaller to 5.8.0
